### PR TITLE
Fixup OilLibrary conda recipe to match requirements in WebGnomeAPI

### DIFF
--- a/oil_library/oil_library_conda_recipe/meta.yaml
+++ b/oil_library/oil_library_conda_recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
-  name: oil_library
-  version: 0.0
+  name: oillibrary
+  version: 0.1
 
 # no source -- source is local
 
@@ -15,6 +15,7 @@ requirements:
     - awesome-slugify
     - unit_conversion
     - pytest
+    - repoze.lru
   run:
     - numpy
     - python
@@ -24,6 +25,7 @@ requirements:
     - awesome-slugify
     - pytest
     - unit_conversion
+    - repoze.lru
 
 about:
   home: https://github.com/NOAA-ORR-ERD/PyGnome


### PR DESCRIPTION
WebGnomeAPI expected the library to be named `OilLibrary` instead of `oil_library` (case insensitive, i think, but the underscore change is important), and also expected it to be version `0.1`.