### PR TITLE
`psutil` update

### DIFF
--- a/conda_packages.txt
+++ b/conda_packages.txt
@@ -13,7 +13,7 @@ pyzmq
 cython
 pytest
 testfixtures
-psutil
+psutil>=2.0
 sphinx
 progressbar
 six

--- a/py_gnome/gnome/multi_model_broadcast.py
+++ b/py_gnome/gnome/multi_model_broadcast.py
@@ -84,7 +84,7 @@ class ModelConsumer(mp.Process):
 
     def cleanup_inherited_files(self):
         proc = psutil.Process(os.getpid())
-        [os.close(c.fd) for c in proc.get_connections()]
+        [os.close(c.fd) for c in proc.connections()]
         # [os.close(f.fd) for f in proc.get_open_files()]
 
     def handle_cmd(self, msg):


### PR DESCRIPTION
Use `psutil` >= 2.0 for a consistent API. This will now work for both `psutil` 2.0 and 3.0.