### PR TITLE
py23 branch: Fix SpatialRelease passing start_position argument instead of custom_positions

### DIFF
--- a/py_gnome/gnome/spill/release.py
+++ b/py_gnome/gnome/spill/release.py
@@ -997,6 +997,7 @@ def GridRelease(release_time, bounds, resolution):
     return SpatialRelease(release_time=release_time,
                           custom_positions=positions,
                           num_elements=len(positions),
+                          )
 
 
 class ContinuousSpatialRelease(SpatialRelease):

--- a/py_gnome/gnome/spill/release.py
+++ b/py_gnome/gnome/spill/release.py
@@ -990,7 +990,7 @@ def GridRelease(release_time, bounds, resolution):
     positions = np.c_[lon.flat, lat.flat, np.zeros((resolution * resolution),)]
 
     return SpatialRelease(release_time=release_time,
-                          start_position=positions)
+                          custom_positions=positions)
 
 
 class ContinuousSpatialRelease(SpatialRelease):

--- a/py_gnome/gnome/spill/spill.py
+++ b/py_gnome/gnome/spill/spill.py
@@ -772,7 +772,7 @@ def spatial_release_spill(start_positions,
     A spatial release is a spill that releases elements at known locations.
     '''
     release = SpatialRelease(release_time=release_time,
-                             start_position=start_positions,
+                             custom_positions=start_positions,
                              name=name)
     retv = Spill(release=release,
                  water=water,


### PR DESCRIPTION
This passes the correct arguments to the SpatialRelease class.