### PR TITLE
Fix logo url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 
-.. image:: graphics/new_gnome_icon/GNOME_logo_450px-wide.png)
+.. image:: graphics/new_gnome_icon/GNOME_logo_450px-wide.png
    :alt: GNOME Logo
    :align: center
 


### PR DESCRIPTION
The logo URL in the README has a trailing bracket. This PR fixes that so the logo is shown fine.