### PR TITLE
Introduced DB (e.g. Postgis) Outputter

### DIFF
--- a/py_gnome/gnome/outputters/postgis.py
+++ b/py_gnome/gnome/outputters/postgis.py
@@ -1,6 +1,7 @@
 # gnome/outputters/postgis.py
 
 import logging
+
 from gnome.outputters.geo_json import TrajectoryGeoJsonOutput
 
 log = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ class PostGISOutput(TrajectoryGeoJsonOutput):
         super().write_output(step_num, islast_step)
 
         if not self._write_step:
-            return None
+            return
 
         rows = []
         for sc in self.cache.load_timestep(step_num).items():
@@ -111,5 +112,3 @@ class PostGISOutput(TrajectoryGeoJsonOutput):
                 self._persist(rows)
             except Exception:
                 log.exception("persist failed at step %d", step_num)
-
-        return None

--- a/py_gnome/gnome/outputters/postgis.py
+++ b/py_gnome/gnome/outputters/postgis.py
@@ -1,0 +1,115 @@
+# gnome/outputters/postgis.py
+
+import logging
+from gnome.outputters.geo_json import TrajectoryGeoJsonOutput
+
+log = logging.getLogger(__name__)
+
+
+class PostGISOutput(TrajectoryGeoJsonOutput):
+    """
+    Writes spill element data (position, status, mass) to a PostGIS-enabled
+    PostgreSQL database at each model timestep.
+
+    The caller is responsible for providing a ``row_factory`` callable that
+    converts a single element dict into whatever row object or dict their
+    schema expects, and a ``persist`` callable that receives a list of those
+    rows and writes them to the database.
+
+    This keeps the outputter decoupled from any specific ORM, connection pool,
+    or application framework.
+
+    Parameters
+    ----------
+    persist : callable
+        ``persist(rows: list) -> None``
+        Called once per timestep with all rows for that step.
+        Responsible for opening a connection/session, writing, and committing.
+
+    row_factory : callable, optional
+        ``row_factory(element: dict) -> any``
+        Converts a single element dict (keys: time, lon, lat, depth,
+        status_code, mass, step, element_index) into whatever object
+        your persistence layer expects (ORM instance, plain dict, tuple…).
+        Defaults to returning the element dict unchanged.
+
+    run_id : str, optional
+        Arbitrary identifier for this model run (task ID, UUID, etc.).
+        Passed into each element dict as ``run_id`` so your row_factory
+        can store it. Default is None.
+
+    metadata : dict, optional
+        Any additional key/value pairs to attach to every row.
+        Merged into each element dict before row_factory is called.
+
+    round_data : bool
+        Round float arrays. Default True.
+
+    round_to : int
+        Decimal places for rounding. Default 4.
+
+    output_dir : str, optional
+        Only needed if you also want file output from the parent class.
+    """
+
+    def __init__(self,
+                 persist,
+                 row_factory=None,
+                 run_id=None,
+                 metadata=None,
+                 round_data=True,
+                 round_to=4,
+                 output_dir=None,
+                 **kwargs):
+        super().__init__(round_data, round_to, output_dir, **kwargs)
+
+        if not callable(persist):
+            raise TypeError("persist must be a callable: persist(rows) -> None")
+        if row_factory is not None and not callable(row_factory):
+            raise TypeError("row_factory must be a callable: row_factory(element) -> row")
+
+        self._persist = persist
+        self._row_factory = row_factory or (lambda x: x)
+        self.run_id = run_id
+        self.metadata = metadata or {}
+
+    def write_output(self, step_num, islast_step=False):
+        super().write_output(step_num, islast_step)
+
+        if not self._write_step:
+            return None
+
+        rows = []
+        for sc in self.cache.load_timestep(step_num).items():
+            positions   = self._dataarray_p_types(sc['positions'])
+            status_codes = self._dataarray_p_types(sc['status_codes'])
+            masses      = self._dataarray_p_types(sc['mass'])
+            timestamp   = sc.current_time_stamp.isoformat()
+
+            for ix, pos in enumerate(positions):
+                element = {
+                    'run_id':       self.run_id,
+                    'step':         step_num,
+                    'element_index': ix,
+                    'time':         timestamp,
+                    'lon':          pos[0],
+                    'lat':          pos[1],
+                    'depth':        pos[2],
+                    'status_code':  status_codes[ix],
+                    'mass':         masses[ix],
+                }
+                element.update(self.metadata)
+
+                try:
+                    rows.append(self._row_factory(element))
+                except Exception:
+                    log.exception("row_factory failed for element %d at step %d",
+                                  ix, step_num)
+
+        if rows:
+            try:
+                self._persist(rows)
+            except Exception:
+                log.exception("persist failed at step %d", step_num)
+
+        return None

--- a/py_gnome/gnome/outputters/postgis.py
+++ b/py_gnome/gnome/outputters/postgis.py
@@ -1,13 +1,16 @@
 # gnome/outputters/postgis.py
 
 import logging
+from datetime import timezone
 
-from gnome.outputters.geo_json import TrajectoryGeoJsonOutput
+import numpy as np
+
+from gnome.outputters.outputter import Outputter
 
 log = logging.getLogger(__name__)
 
 
-class PostGISOutput(TrajectoryGeoJsonOutput):
+class PostGISOutput(Outputter):
     """
     Writes spill element data (position, status, mass) to a PostGIS-enabled
     PostgreSQL database at each model timestep.
@@ -48,9 +51,6 @@ class PostGISOutput(TrajectoryGeoJsonOutput):
 
     round_to : int
         Decimal places for rounding. Default 4.
-
-    output_dir : str, optional
-        Only needed if you also want file output from the parent class.
     """
 
     def __init__(self,
@@ -60,9 +60,8 @@ class PostGISOutput(TrajectoryGeoJsonOutput):
                  metadata=None,
                  round_data=True,
                  round_to=4,
-                 output_dir=None,
                  **kwargs):
-        super().__init__(round_data, round_to, output_dir, **kwargs)
+        super().__init__(**kwargs)
 
         if not callable(persist):
             raise TypeError("persist must be a callable: persist(rows) -> None")
@@ -73,6 +72,18 @@ class PostGISOutput(TrajectoryGeoJsonOutput):
         self._row_factory = row_factory or (lambda x: x)
         self.run_id = run_id
         self.metadata = metadata or {}
+        self.round_data = round_data
+        self.round_to = round_to
+
+    def _dataarray_p_types(self, data_array):
+        if issubclass(data_array.dtype.type, float):
+            return data_array.round(self.round_to).astype(float).tolist()
+        elif issubclass(data_array.dtype.type, np.integer):
+            return data_array.astype(int).tolist()
+        else:
+            raise TypeError(
+                "PostGISOutput can only handle float or integer array types"
+            )
 
     def write_output(self, step_num, islast_step=False):
         super().write_output(step_num, islast_step)
@@ -80,24 +91,26 @@ class PostGISOutput(TrajectoryGeoJsonOutput):
         if not self._write_step:
             return
 
+        tz = timezone(self.timezone_offset.as_timedelta())
+
         rows = []
         for sc in self.cache.load_timestep(step_num).items():
-            positions   = self._dataarray_p_types(sc['positions'])
+            positions = self._dataarray_p_types(sc['positions'])
             status_codes = self._dataarray_p_types(sc['status_codes'])
-            masses      = self._dataarray_p_types(sc['mass'])
-            timestamp   = sc.current_time_stamp.isoformat()
+            masses = self._dataarray_p_types(sc['mass'])
+            timestamp = sc.current_time_stamp.replace(tzinfo=tz).isoformat()
 
             for ix, pos in enumerate(positions):
                 element = {
-                    'run_id':       self.run_id,
-                    'step':         step_num,
+                    'run_id': self.run_id,
+                    'step': step_num,
                     'element_index': ix,
-                    'time':         timestamp,
-                    'lon':          pos[0],
-                    'lat':          pos[1],
-                    'depth':        pos[2],
+                    'time': timestamp,
+                    'lon': pos[0],
+                    'lat': pos[1],
+                    'depth': pos[2],
                     'status_code':  status_codes[ix],
-                    'mass':         masses[ix],
+                    'mass': masses[ix],
                 }
                 element.update(self.metadata)
 

--- a/py_gnome/tests/unit_tests/test_outputters/test_postgis.py
+++ b/py_gnome/tests/unit_tests/test_outputters/test_postgis.py
@@ -7,14 +7,13 @@ No real database is used; persist/row_factory are plain callables.
 import pytest
 from datetime import datetime, timedelta
 
-import numpy as np
-
 from gnome.model import Model
 from gnome.maps import MapFromBNA
 from gnome.movers import SimpleMover
 from gnome.spills.spill import point_line_spill
 from gnome.spills.substance import NonWeatheringSubstance
 from gnome.outputters.postgis import PostGISOutput
+from gnome.utilities.time_utils import TZOffset
 
 import os
 
@@ -171,6 +170,30 @@ class TestModelRun:
 
         steps_seen = [rows[0]["step"] for rows in calls if rows]
         assert steps_seen == sorted(steps_seen)
+
+    def test_timestamp_is_timezone_aware(self, simple_model):
+        received = []
+        out = PostGISOutput(persist=lambda rows: received.extend(rows))
+        simple_model.outputters += out
+        simple_model.full_run()
+
+        assert len(received) > 0
+        for row in received:
+            assert "+" in row["time"] or row["time"].endswith("Z"), (
+                f"Expected tz-aware timestamp, got: {row['time']}"
+            )
+
+    def test_timezone_offset_reflected_in_timestamp(self, simple_model):
+        received = []
+        out = PostGISOutput(
+            persist=lambda rows: received.extend(rows),
+            timezone_offset=TZOffset(offset=-5, title="EST"),
+        )
+        simple_model.outputters += out
+        simple_model.full_run()
+
+        assert len(received) > 0
+        assert all("-05:00" in row["time"] for row in received)
 
 
 # ---------------------------------------------------------------------------

--- a/py_gnome/tests/unit_tests/test_outputters/test_postgis.py
+++ b/py_gnome/tests/unit_tests/test_outputters/test_postgis.py
@@ -40,7 +40,6 @@ def simple_model():
         duration=timedelta(hours=1),
         map=map_,
         uncertain=False,
-        cache_enabled=True,
     )
     model.movers += SimpleMover(velocity=(1.0, -1.0, 0.0))
     spill = point_line_spill(

--- a/py_gnome/tests/unit_tests/test_outputters/test_postgis.py
+++ b/py_gnome/tests/unit_tests/test_outputters/test_postgis.py
@@ -1,0 +1,207 @@
+"""
+Tests for the PostGIS outputter.
+
+No real database is used; persist/row_factory are plain callables.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+
+import numpy as np
+
+from gnome.model import Model
+from gnome.maps import MapFromBNA
+from gnome.movers import SimpleMover
+from gnome.spills.spill import point_line_spill
+from gnome.spills.substance import NonWeatheringSubstance
+from gnome.outputters.postgis import PostGISOutput
+
+import os
+
+_MAPFILE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "sample_data",
+    "MapBounds_Island.bna",
+)
+
+
+@pytest.fixture
+def simple_model():
+    """
+    A minimal model: SimpleMover, one spill, cache enabled, no uncertainty.
+    Suitable for testing outputters without a real DB.
+    """
+    release_time = datetime(2012, 9, 15, 12, 0)
+    map_ = MapFromBNA(_MAPFILE, refloat_halflife=6)
+    model = Model(
+        time_step=timedelta(minutes=15),
+        start_time=release_time,
+        duration=timedelta(hours=1),
+        map=map_,
+        uncertain=False,
+        cache_enabled=True,
+    )
+    model.movers += SimpleMover(velocity=(1.0, -1.0, 0.0))
+    spill = point_line_spill(
+        5,
+        start_position=(-127.1, 47.93, 0.0),
+        release_time=release_time,
+        substance=NonWeatheringSubstance(),
+        amount=100,
+        units='kg',
+    )
+    model.spills += spill
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_valid(self):
+        out = PostGISOutput(persist=lambda rows: None)
+        assert callable(out._persist)
+        assert callable(out._row_factory)
+        assert out.run_id is None
+        assert out.metadata == {}
+        assert out.round_data is True
+        assert out.round_to == 4
+
+    def test_persist_not_callable_raises(self):
+        with pytest.raises(TypeError, match="persist must be a callable"):
+            PostGISOutput(persist="not_a_function")
+
+    def test_row_factory_not_callable_raises(self):
+        with pytest.raises(TypeError, match="row_factory must be a callable"):
+            PostGISOutput(persist=lambda rows: None, row_factory="bad")
+
+    def test_default_row_factory_is_identity(self):
+        out = PostGISOutput(persist=lambda rows: None)
+        sentinel = {"a": 1}
+        assert out._row_factory(sentinel) is sentinel
+
+    def test_run_id_stored(self):
+        out = PostGISOutput(persist=lambda rows: None, run_id="abc-123")
+        assert out.run_id == "abc-123"
+
+    def test_metadata_stored(self):
+        meta = {"scenario": "test"}
+        out = PostGISOutput(persist=lambda rows: None, metadata=meta)
+        assert out.metadata == meta
+
+    def test_metadata_defaults_to_empty_dict(self):
+        out = PostGISOutput(persist=lambda rows: None, metadata=None)
+        assert out.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: model run
+# ---------------------------------------------------------------------------
+
+class TestModelRun:
+    def test_persist_called_each_timestep(self, simple_model):
+        calls = []
+        out = PostGISOutput(persist=lambda rows: calls.append(rows))
+        simple_model.outputters += out
+        simple_model.full_run()
+        assert len(calls) == simple_model.num_time_steps
+
+    def test_rows_have_required_keys(self, simple_model):
+        received = []
+        out = PostGISOutput(persist=lambda rows: received.extend(rows))
+        simple_model.outputters += out
+        simple_model.full_run()
+
+        required = {"run_id", "step", "element_index", "time", "lon", "lat",
+                    "depth", "status_code", "mass"}
+        for row in received:
+            assert required.issubset(row.keys()), (
+                f"Missing keys: {required - row.keys()}"
+            )
+
+    def test_run_id_present_in_every_row(self, simple_model):
+        received = []
+        out = PostGISOutput(
+            persist=lambda rows: received.extend(rows),
+            run_id="run-xyz",
+        )
+        simple_model.outputters += out
+        simple_model.full_run()
+
+        assert len(received) > 0
+        assert all(r["run_id"] == "run-xyz" for r in received)
+
+    def test_metadata_merged_into_rows(self, simple_model):
+        received = []
+        out = PostGISOutput(
+            persist=lambda rows: received.extend(rows),
+            metadata={"scenario": "unit-test", "version": 2},
+        )
+        simple_model.outputters += out
+        simple_model.full_run()
+
+        assert len(received) > 0
+        for row in received:
+            assert row["scenario"] == "unit-test"
+            assert row["version"] == 2
+
+    def test_custom_row_factory_applied(self, simple_model):
+        received = []
+
+        def factory(elem):
+            return {"x": elem["lon"], "y": elem["lat"]}
+
+        out = PostGISOutput(
+            persist=lambda rows: received.extend(rows),
+            row_factory=factory,
+        )
+        simple_model.outputters += out
+        simple_model.full_run()
+
+        assert len(received) > 0
+        for row in received:
+            assert set(row.keys()) == {"x", "y"}
+
+    def test_step_index_increments(self, simple_model):
+        calls = []
+        out = PostGISOutput(persist=lambda rows: calls.append(rows))
+        simple_model.outputters += out
+        simple_model.full_run()
+
+        steps_seen = [rows[0]["step"] for rows in calls if rows]
+        assert steps_seen == sorted(steps_seen)
+
+
+# ---------------------------------------------------------------------------
+# Error resilience
+# ---------------------------------------------------------------------------
+
+class TestErrorResilience:
+    def test_row_factory_exception_does_not_crash(self, simple_model):
+        """A failing row_factory should be logged but not raise."""
+        persist_calls = []
+
+        def bad_factory(elem):
+            raise RuntimeError("factory boom")
+
+        out = PostGISOutput(
+            persist=lambda rows: persist_calls.append(rows),
+            row_factory=bad_factory,
+        )
+        simple_model.outputters += out
+        # Should not raise
+        simple_model.full_run()
+        # persist is called with empty lists (all rows dropped)
+        assert all(len(r) == 0 for r in persist_calls)
+
+    def test_persist_exception_does_not_crash(self, simple_model):
+        """A failing persist should be logged but not raise."""
+        def bad_persist(rows):
+            raise RuntimeError("db boom")
+
+        out = PostGISOutput(persist=bad_persist)
+        simple_model.outputters += out
+        # Should not raise
+        simple_model.full_run()


### PR DESCRIPTION
Added a DB (PostGIS) based outputter to save model results online. The class extends `TrajectoryGeoJsonOutput`, accepting two callables for data preparation and DB insert/commit.

## Example

**Schema** (`app/lib/model/orm_schema.py`)

```python
from datetime import datetime

from geoalchemy2 import Geometry
from sqlalchemy import BigInteger, DateTime, Float, Index, Integer, String, text
from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column


class Base(DeclarativeBase):
    pass


class ResultsRendering(Base):
    """
    Stores per-element, per-timestep output from a PyGNOME model run.

    Each row represents one Lagrangian Element (LE) at one timestep.
    Geometry is stored as a PostGIS 2D Point (EPSG:4326).

    Columns
    -------
    id                  : surrogate primary key
    celery_task_id      : Celery task ID that produced this run
    run_sequence_number : ensemble member index for stochastic runs
    protocol_number     : regulatory or scenario identifier
    step                : model timestep index (0-based)
    geom_id             : element index within the spill container at this step
    time                : ISO 8601 timestamp of this timestep
    depth               : depth in metres (positive = below surface)
    status_code_point   : PyGNOME oil_status integer
                            0  = not_released
                            2  = in_water
                            3  = on_land
                            7  = off_maps
                            10 = evaporated
                            12 = to_be_removed
    mass_point          : element mass in grams
    geom_point          : PostGIS Point (lon, lat, EPSG:4326)
    created_at          : row insertion timestamp, set by DB default
    """

    __tablename__ = "results_rendering"

    id: Mapped[int] = mapped_column(
        BigInteger, primary_key=True, autoincrement=True
    )
    celery_task_id: Mapped[str] = mapped_column(
        String(255), nullable=False, index=True
    )
    run_sequence_number: Mapped[int] = mapped_column(
        Integer, nullable=False, default=0
    )
    protocol_number: Mapped[str] = mapped_column(
        String(100), nullable=False
    )
    step: Mapped[int] = mapped_column(Integer, nullable=False)
    geom_id: Mapped[int] = mapped_column(
        Integer, nullable=False,
        comment="Element index within the spill container at this timestep",
    )
    time: Mapped[str] = mapped_column(
        String(50), nullable=False,
        comment="ISO 8601 timestamp string from sc.current_time_stamp",
    )
    depth: Mapped[float] = mapped_column(
        Float, nullable=False, default=0.0,
        comment="Depth in metres, positive below surface",
    )
    status_code_point: Mapped[int] = mapped_column(
        Integer, nullable=False,
        comment="PyGNOME oil_status integer code for this element",
    )
    mass_point: Mapped[float] = mapped_column(
        Float, nullable=False,
        comment="Element mass in grams",
    )
    geom_point: Mapped[str] = mapped_column(
        Geometry(geometry_type="POINT", srid=4326, dimension=2),
        nullable=False,
        comment="Lon/lat position as PostGIS Point",
    )
    created_at: Mapped[datetime] = mapped_column(
        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
    )

    __table_args__ = (
        Index("ix_results_rendering_task_step", "celery_task_id", "step"),
        Index(
            "ix_results_rendering_geom",
            "geom_point",
            postgresql_using="gist",
        ),
        Index(
            "ix_results_rendering_task_seq",
            "celery_task_id",
            "run_sequence_number",
        ),
    )

    def __repr__(self) -> str:
        return (
            f"<ResultsRendering("
            f"task={self.celery_task_id!r}, "
            f"step={self.step}, "
            f"geom_id={self.geom_id}, "
            f"status={self.status_code_point}"
            f")>"
        )
```

**Row factory and persist** (`app/lib/outputters/postgis_wiring.py`)

```python
from __future__ import annotations

import logging

from geoalchemy2.shape import from_shape
from shapely.geometry import Point
from sqlalchemy.exc import SQLAlchemyError

from app.lib import get_db
from app.lib.model.orm_schema import ResultsRendering

log = logging.getLogger(__name__)


def make_row(element: dict) -> ResultsRendering:
    """
    Convert a single element dict produced by PostGISOutput into a
    ResultsRendering ORM instance.

    Expected keys in ``element``
    ----------------------------
    run_id               : str   — Celery task ID
    step                 : int   — timestep index
    element_index        : int   — LE index within the spill container
    time                 : str   — ISO 8601 timestamp
    lon                  : float — longitude (EPSG:4326)
    lat                  : float — latitude (EPSG:4326)
    depth                : float — depth in metres, positive below surface
    status_code          : int   — PyGNOME oil_status code
    mass                 : float — element mass in grams
    run_sequence_number  : int   — ensemble member index (stochastic runs)
    protocol_number      : str   — regulatory / scenario identifier
    """
    try:
        geom = from_shape(
            Point(float(element["lon"]), float(element["lat"])),
            srid=4326,
        )
    except Exception as exc:
        raise ValueError(
            f"Could not build geometry for element {element.get('element_index')} "
            f"at step {element.get('step')}: "
            f"lon={element.get('lon')}, lat={element.get('lat')}"
        ) from exc

    return ResultsRendering(
        celery_task_id=str(element["run_id"]),
        run_sequence_number=int(element.get("run_sequence_number", 0)),
        protocol_number=str(element.get("protocol_number", "")),
        step=int(element["step"]),
        geom_id=int(element["element_index"]),
        time=str(element["time"]),
        depth=float(element["depth"]),
        status_code_point=int(element["status_code"]),
        mass_point=float(element["mass"]),
        geom_point=geom,
    )


def persist(rows: list[ResultsRendering], batch_size: int = 500) -> None:
    """
    Bulk-insert a list of ResultsRendering rows into the database.

    Inserts in batches of ``batch_size`` to avoid overwhelming the connection
    on large timesteps. Each batch is committed independently so a failure
    only rolls back that batch, not the entire timestep.

    Parameters
    ----------
    rows       : list of ResultsRendering ORM instances
    batch_size : rows per INSERT batch (default 500)
    """
    if not rows:
        return

    total = len(rows)
    inserted = 0

    for batch_start in range(0, total, batch_size):
        batch = rows[batch_start : batch_start + batch_size]
        try:
            with get_db() as db:
                db.bulk_save_objects(batch)
                db.commit()
            inserted += len(batch)
        except SQLAlchemyError:
            log.exception(
                "Failed to insert batch rows %d-%d (step contains %d total rows). "
                "Batch rolled back; continuing with next batch.",
                batch_start,
                batch_start + len(batch) - 1,
                total,
            )

    if inserted < total:
        log.warning(
            "Only %d of %d rows were successfully inserted.", inserted, total
        )
    else:
        log.debug("Inserted %d rows.", inserted)
```

**Wiring to the model**

```python
from gnome.outputters.postgis import PostGISOutput
from app.lib.outputters.postgis_wiring import make_row, persist

outputter = PostGISOutput(
    persist=persist,
    row_factory=make_row,
    run_id=celery_task.id,
    metadata={
        "run_sequence_number": run_sequence_number,
        "protocol_number": protocol_number,
    },
)

model.outputters += outputter
```